### PR TITLE
Separately running game threads. No real communication between them yet.

### DIFF
--- a/docs/design/application/tasks.md
+++ b/docs/design/application/tasks.md
@@ -1,0 +1,27 @@
+## Thread Architecture Foundation task list:
+
+### Phase 1: Thread Structure Setup (High Priority)
+
+[ ] 1. Implement Thread Coordinator - thread lifecycle management and creation
+[ ] 2. Create Main Thread structure - SDL3 event loop with thread coordination
+[ ] 3. Implement Game Thread - basic game loop structure and timing
+[ ] 4. Create Render Thread - basic thread structure and frame timing
+[ ] 5. Implement Audio Thread - basic thread structure and SDL3 audio setup
+[ ] 6. Create thread shutdown coordination - graceful termination across all threads
+
+### Phase 2: Inter-Thread Communication (High Priority)
+
+[ ] 7. Design thread-safe communication data structures - Input Buffer, Render Packet Buffer, Audio Packet Buffer
+[ ] 8. Design and implement Input Event Buffer - lock-free circular buffer with frame numbering
+[ ] 9. Design and implement Render Packet Buffer - double/triple buffered structure for render data
+[ ] 10. Design and implement Audio Packet Buffer - double buffered structure for audio events
+
+### Phase 3: Integration and Testing (Medium Priority)
+
+[ ] 11. Implement Control Message System - mutex-protected messaging for thread coordination
+[ ] 12. Connect Game Thread input consumption to Input Event Buffer
+[ ] 13. Connect Game Thread packet generation to Render and Audio buffers
+[ ] 14. Implement basic error handling and thread health monitoring
+[ ] 15. Add thread-safe logging infrastructure with per-thread buffers
+[ ] 16. Integrate threading system with existing app structure and game API loading
+[ ] 17. Test thread communication and verify frame-independent operation

--- a/docs/scratch.md
+++ b/docs/scratch.md
@@ -471,4 +471,3 @@ This design enables a build tool that becomes the central orchestrator for all d
 
 The result is a build system that transforms `./build -profile release-full` into a complete end-to-end release process, automating everything from compilation to community communication.
 
-

--- a/src/app/app.odin
+++ b/src/app/app.odin
@@ -33,6 +33,9 @@ app_init :: proc() {
 }
 
 app_init_wait :: proc() {
+	// TODO: If a thread fails during it initialization it will return and never be initialized.
+	// It should also mark itself as failed so we can check for that within this loop.
+
 	initialization_wait: time.Stopwatch
 	time.stopwatch_start(&initialization_wait)
 	for !app_thread_data.initialized ||

--- a/src/app/develop.odin
+++ b/src/app/develop.odin
@@ -1,0 +1,42 @@
+package app
+
+import "core:log"
+import "core:sync"
+import "core:thread"
+import "core:time"
+
+game_thread_proc_develop :: proc(t: ^thread.Thread) {
+	context.logger = log.create_console_logger(opt = log_opts)
+
+	log.debug("Development game thread starting...")
+	defer log.debug("Development game thread exiting...")
+
+	thread_data := cast(^GameThreadData)t.data
+
+	// TODO: How to do this statically for release builds?
+	game, ok := game_api_load()
+	if !ok {return}
+	defer game_api_unload(game)
+	thread_data.game_api = game
+
+	thread_data.game_api.init()
+	defer thread_data.game_api.deinit()
+
+	thread_data.initialized = true
+
+	// I think I need to wait for other threads to finish initialization before I start the game update.
+	// Don't want to load in a scene/interact with the game before render thread finishes (I think? headless?)
+
+	for {
+		sync.mutex_lock(&app_threads.shutdown_mutex)
+		shutdown_requested := app_threads.shutdown_requested
+		sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+		if shutdown_requested {break}
+
+		thread_data.game_api.update()
+
+		time.sleep(time.Millisecond * 10)
+	}
+}
+

--- a/src/app/game_api.odin
+++ b/src/app/game_api.odin
@@ -59,6 +59,8 @@ game_api_load :: proc() -> (GameAPI, bool) {
 		return GameAPI{}, false
 	}
 
+	log.debugf("Loaded game library: {0}", game_api_path(id))
+
 	return api, true
 }
 

--- a/src/app/release.odin
+++ b/src/app/release.odin
@@ -7,7 +7,7 @@ import "core:time"
 
 import "../game"
 
-game_thread_proc_release :: proc(t: ^thread.Thread) {
+game_entry_proc_release :: proc(t: ^thread.Thread) {
 	context.logger = log.create_console_logger(opt = log_opts)
 
 	log.debug("Game thread starting...")
@@ -24,9 +24,9 @@ game_thread_proc_release :: proc(t: ^thread.Thread) {
 	// Don't want to load in a scene/interact with the game before render thread finishes (I think? headless?)
 
 	for {
-		sync.mutex_lock(&app_threads.shutdown_mutex)
-		shutdown_requested := app_threads.shutdown_requested
-		sync.mutex_unlock(&app_threads.shutdown_mutex)
+		sync.mutex_lock(&state.threads.shutdown_mutex)
+		shutdown_requested := state.threads.shutdown_requested
+		sync.mutex_unlock(&state.threads.shutdown_mutex)
 
 		if shutdown_requested {break}
 

--- a/src/app/release.odin
+++ b/src/app/release.odin
@@ -1,0 +1,38 @@
+package app
+
+import "core:log"
+import "core:sync"
+import "core:thread"
+import "core:time"
+
+import "../game"
+
+game_thread_proc_release :: proc(t: ^thread.Thread) {
+	context.logger = log.create_console_logger(opt = log_opts)
+
+	log.debug("Game thread starting...")
+	defer log.debug("Game thread exiting...")
+
+	thread_data := cast(^GameThreadData)t.data
+
+	game.game_init()
+	defer game.game_deinit()
+
+	thread_data.initialized = true
+
+	// I think I need to wait for other threads to finish initialization before I start the game update.
+	// Don't want to load in a scene/interact with the game before render thread finishes (I think? headless?)
+
+	for {
+		sync.mutex_lock(&app_threads.shutdown_mutex)
+		shutdown_requested := app_threads.shutdown_requested
+		sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+		if shutdown_requested {break}
+
+		game.game_update()
+
+		time.sleep(time.Millisecond * 10)
+	}
+}
+

--- a/src/app/threads.odin
+++ b/src/app/threads.odin
@@ -1,0 +1,162 @@
+package app
+
+import "core:log"
+import "core:sync"
+import "core:thread"
+import "core:time"
+
+ThreadID :: enum {
+	GAME,
+	RENDER,
+	AUDIO,
+}
+
+ThreadCount: int : 3
+
+AppThreads :: struct {
+	threads:            [ThreadCount]^thread.Thread,
+	shutdown_requested: bool,
+	shutdown_mutex:     sync.Mutex,
+}
+
+app_threads: AppThreads
+
+game_data: GameThreadData
+render_data: RenderThreadData
+audio_data: AudioThreadData
+
+app_threads_init :: proc() -> bool {
+	game_thread_idx := cast(int)ThreadID.GAME
+	game_thread := thread.create(game_thread_proc)
+	game_thread.user_index = game_thread_idx
+	game_thread.data = &game_data
+	app_threads.threads[game_thread_idx] = game_thread
+
+	render_thread_idx := cast(int)ThreadID.RENDER
+	render_thread := thread.create(render_thread_proc)
+	render_thread.user_index = render_thread_idx
+	render_thread.data = &render_data
+	app_threads.threads[render_thread_idx] = render_thread
+
+	audio_thread_idx := cast(int)ThreadID.AUDIO
+	audio_thread := thread.create(audio_thread_proc)
+	audio_thread.user_index = audio_thread_idx
+	audio_thread.data = &audio_data
+	app_threads.threads[audio_thread_idx] = audio_thread
+
+	return true
+}
+
+app_threads_start :: proc() {
+	log.debug("Starting threads...")
+
+	for i in 0 ..< ThreadCount {
+		assert(app_threads.threads[i] != nil, "Thread must be initialized before starting.")
+		thread.start(app_threads.threads[i])
+	}
+}
+
+app_threads_stop :: proc() -> bool {
+	log.debug("Stopping threads...")
+
+	sync.mutex_lock(&app_threads.shutdown_mutex)
+	app_threads.shutdown_requested = true
+	sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+	for i in 0 ..< ThreadCount {
+		if app_threads.threads[i] == nil {
+			log.debugf("Thread {} is nil, skipping shutdown.", ThreadID(i))
+			continue
+		}
+
+		log.debugf("Stopping thread {}...", ThreadID(i))
+
+		thread.join(app_threads.threads[i])
+	}
+
+	for i in 0 ..< ThreadCount {
+		if app_threads.threads[i] == nil {continue}
+		thread.destroy(app_threads.threads[i])
+	}
+
+	return true
+}
+
+AppThreadData :: struct {
+	initialized: bool,
+}
+
+app_thread_data: AppThreadData
+
+GameThreadData :: struct {
+	initialized: bool,
+}
+
+game_thread_proc :: proc(t: ^thread.Thread) {
+	context.logger = log.create_console_logger(opt = log_opts)
+
+	log.debug("Game thread starting...")
+	defer log.debug("Game thread exiting...")
+
+	thread_data := cast(^GameThreadData)t.data
+	thread_data.initialized = true
+
+	for {
+		sync.mutex_lock(&app_threads.shutdown_mutex)
+		shutdown_requested := app_threads.shutdown_requested
+		sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+		if shutdown_requested {break}
+
+		time.sleep(time.Millisecond * 10)
+	}
+}
+
+RenderThreadData :: struct {
+	initialized: bool,
+}
+
+render_thread_proc :: proc(t: ^thread.Thread) {
+	context.logger = log.create_console_logger(opt = log_opts)
+
+	log.debug("Render thread starting...")
+	defer log.debug("Render thread exiting...")
+
+	thread_data := cast(^RenderThreadData)t.data
+	thread_data.initialized = true
+
+	for {
+		sync.mutex_lock(&app_threads.shutdown_mutex)
+		shudown_requested := app_threads.shutdown_requested
+		sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+		if shudown_requested {break}
+
+		time.sleep(time.Millisecond * 10)
+	}
+}
+
+AudioThreadData :: struct {
+	initialized: bool,
+}
+
+audio_thread_proc :: proc(t: ^thread.Thread) {
+	context.logger = log.create_console_logger(opt = log_opts)
+
+	log.debug("Audio thread starting...")
+	defer log.debug("Audio thread exiting...")
+
+	thread_data := cast(^AudioThreadData)t.data
+	thread_data.initialized = true
+
+	for {
+		sync.mutex_lock(&app_threads.shutdown_mutex)
+		shudown_requested := app_threads.shutdown_requested
+		sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+		if shudown_requested {break}
+
+		time.sleep(time.Millisecond * 10)
+	}
+}
+

--- a/src/app/threads.odin
+++ b/src/app/threads.odin
@@ -27,7 +27,12 @@ audio_data: AudioThreadData
 
 app_threads_init :: proc() -> bool {
 	game_thread_idx := cast(int)ThreadID.GAME
-	game_thread := thread.create(game_thread_proc)
+	game_thread: ^thread.Thread
+	when ODIN_DEBUG {
+		game_thread = thread.create(game_thread_proc_develop)
+	} else {
+		game_thread = thread.create(game_thread_proc_release)
+	}
 	game_thread.user_index = game_thread_idx
 	game_thread.data = &game_data
 	app_threads.threads[game_thread_idx] = game_thread
@@ -91,41 +96,6 @@ app_thread_data: AppThreadData
 GameThreadData :: struct {
 	initialized: bool,
 	game_api:    GameAPI,
-}
-
-game_thread_proc :: proc(t: ^thread.Thread) {
-	context.logger = log.create_console_logger(opt = log_opts)
-
-	log.debug("Game thread starting...")
-	defer log.debug("Game thread exiting...")
-
-	thread_data := cast(^GameThreadData)t.data
-
-	// TODO: How to do this statically for release builds?
-	game, ok := game_api_load()
-	if !ok {return}
-	defer game_api_unload(game)
-	thread_data.game_api = game
-
-	thread_data.game_api.init()
-	defer thread_data.game_api.deinit()
-
-	thread_data.initialized = true
-
-	// I think I need to wait for other threads to finish initialization before I start the game update.
-	// Don't want to load in a scene/interact with the game before render thread finishes (I think? headless?)
-
-	for {
-		sync.mutex_lock(&app_threads.shutdown_mutex)
-		shutdown_requested := app_threads.shutdown_requested
-		sync.mutex_unlock(&app_threads.shutdown_mutex)
-
-		if shutdown_requested {break}
-
-		thread_data.game_api.update()
-
-		time.sleep(time.Millisecond * 10)
-	}
 }
 
 RenderThreadData :: struct {

--- a/src/entry/develop/main.odin
+++ b/src/entry/develop/main.odin
@@ -17,13 +17,6 @@ main :: proc() {
 	app.app_init()
 	defer app.app_deinit()
 
-	game, ok := app.game_api_load()
-	if !ok {return}
-	defer app.game_api_unload(game)
-
-	game_init(game)
-	defer game_deinit(game)
-
 	app.app_thread_data.initialized = true
 	app.app_init_wait()
 
@@ -34,22 +27,6 @@ main :: proc() {
 
 	for {
 		if quit := app.sdl_poll_events(); quit {break}
-		game_update(game)
 	}
-}
-
-game_init :: proc "c" (game: app.GameAPI) {
-	context = runtime.default_context()
-	game.init()
-}
-
-game_deinit :: proc "c" (game: app.GameAPI) {
-	context = runtime.default_context()
-	game.deinit()
-}
-
-game_update :: proc "c" (game: app.GameAPI) {
-	context = runtime.default_context()
-	game.update()
 }
 

--- a/src/entry/develop/main.odin
+++ b/src/entry/develop/main.odin
@@ -7,6 +7,143 @@ import "core:encoding/uuid"
 import "core:fmt"
 import "core:log"
 import "core:strings"
+import "core:sync"
+import "core:thread"
+import "core:time"
+
+ThreadID :: enum {
+	GAME,
+	RENDER,
+	AUDIO,
+}
+
+ThreadCount: int : 3
+
+AppThreads :: struct {
+	threads:            [ThreadCount]^thread.Thread,
+	shutdown_requested: bool,
+	shutdown_mutex:     sync.Mutex,
+}
+
+app_threads: AppThreads
+
+game_data: GameThreadData
+render_data: RenderThreadData
+audio_data: AudioThreadData
+
+app_threads_init :: proc() -> bool {
+	game_thread_idx := cast(int)ThreadID.GAME
+	game_thread := thread.create(game_thread_proc)
+	game_thread.user_index = game_thread_idx
+	game_thread.data = &game_data
+	app_threads.threads[game_thread_idx] = game_thread
+
+	render_thread_idx := cast(int)ThreadID.RENDER
+	render_thread := thread.create(render_thread_proc)
+	render_thread.user_index = render_thread_idx
+	render_thread.data = &render_data
+	app_threads.threads[render_thread_idx] = render_thread
+
+	audio_thread_idx := cast(int)ThreadID.AUDIO
+	audio_thread := thread.create(audio_thread_proc)
+	audio_thread.user_index = audio_thread_idx
+	audio_thread.data = &audio_data
+	app_threads.threads[audio_thread_idx] = audio_thread
+
+	return true
+}
+
+app_threads_start :: proc() {
+	log.debug("Starting threads...")
+
+	for i in 0 ..< ThreadCount {
+		assert(app_threads.threads[i] != nil, "Thread must be initialized before starting.")
+		thread.start(app_threads.threads[i])
+	}
+}
+
+app_threads_stop :: proc() -> bool {
+	log.debug("Stopping threads...")
+
+	sync.mutex_lock(&app_threads.shutdown_mutex)
+	app_threads.shutdown_requested = true
+	sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+	for i in 0 ..< ThreadCount {
+		if app_threads.threads[i] == nil {
+			log.debugf("Thread {} is nil, skipping shutdown.", ThreadID(i))
+			continue
+		}
+
+		log.debugf("Stopping thread {}...", ThreadID(i))
+
+		thread.join(app_threads.threads[i])
+	}
+
+	for i in 0 ..< ThreadCount {
+		if app_threads.threads[i] == nil {continue}
+		thread.destroy(app_threads.threads[i])
+	}
+
+	return true
+}
+
+GameThreadData :: struct {}
+
+game_thread_proc :: proc(t: ^thread.Thread) {
+	context.logger = log.create_console_logger()
+
+	log.debug("Game thread starting...")
+	defer log.debug("Game thread exiting...")
+
+	for {
+		sync.mutex_lock(&app_threads.shutdown_mutex)
+		shutdown_requested := app_threads.shutdown_requested
+		sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+		if shutdown_requested {break}
+
+		time.sleep(time.Millisecond * 10)
+	}
+}
+
+RenderThreadData :: struct {}
+
+render_thread_proc :: proc(t: ^thread.Thread) {
+	context.logger = log.create_console_logger()
+
+	log.debug("Render thread starting...")
+	defer log.debug("Render thread exiting...")
+
+	for {
+		sync.mutex_lock(&app_threads.shutdown_mutex)
+		shudown_requested := app_threads.shutdown_requested
+		sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+		if shudown_requested {break}
+
+		time.sleep(time.Millisecond * 10)
+	}
+}
+
+AudioThreadData :: struct {}
+
+audio_thread_proc :: proc(t: ^thread.Thread) {
+	context.logger = log.create_console_logger()
+
+	log.debug("Audio thread starting...")
+	defer log.debug("Audio thread exiting...")
+
+	for {
+		sync.mutex_lock(&app_threads.shutdown_mutex)
+		shudown_requested := app_threads.shutdown_requested
+		sync.mutex_unlock(&app_threads.shutdown_mutex)
+
+		if shudown_requested {break}
+
+		time.sleep(time.Millisecond * 10)
+	}
+}
 
 main :: proc() {
 	context.logger = log.create_console_logger()
@@ -18,6 +155,11 @@ main :: proc() {
 	app.sdl_init()
 	defer app.sdl_deinit()
 
+	app_threads_init()
+	defer app_threads_stop()
+
+	app_threads_start()
+
 	game, ok := app.game_api_load()
 	if !ok {return}
 	defer app.game_api_unload(game)
@@ -26,6 +168,9 @@ main :: proc() {
 	defer game_deinit(game)
 
 	if app.cli_options().check {
+		// TODO
+		// Wait for all threads to finish initialization
+
 		log.info("App initialized successfully, exiting.")
 		return
 	}

--- a/src/entry/develop/main.odin
+++ b/src/entry/develop/main.odin
@@ -17,17 +17,18 @@ main :: proc() {
 	app.app_init()
 	defer app.app_deinit()
 
-	app.app_thread_data.initialized = true
-	app.app_init_wait()
-
 	if app.cli_options().check {
 		log.info("App initialized successfully, exiting.")
 		return
 	}
 
 	for {
+		app.thread_clock_frame_start(&app.state.threads.app_data.clock)
+
 		if quit := app.sdl_poll_events(); quit {break}
-		time.sleep(10 * time.Millisecond)
+
+		app.thread_clock_frame_end(&app.state.threads.app_data.clock)
+		app.thread_clock_sleep(&app.state.threads.app_data.clock)
 	}
 }
 

--- a/src/entry/develop/main.odin
+++ b/src/entry/develop/main.odin
@@ -6,159 +6,16 @@ import "core:dynlib"
 import "core:encoding/uuid"
 import "core:fmt"
 import "core:log"
+import "core:os"
+import "core:strconv"
 import "core:strings"
-import "core:sync"
-import "core:thread"
 import "core:time"
 
-ThreadID :: enum {
-	GAME,
-	RENDER,
-	AUDIO,
-}
-
-ThreadCount: int : 3
-
-AppThreads :: struct {
-	threads:            [ThreadCount]^thread.Thread,
-	shutdown_requested: bool,
-	shutdown_mutex:     sync.Mutex,
-}
-
-app_threads: AppThreads
-
-game_data: GameThreadData
-render_data: RenderThreadData
-audio_data: AudioThreadData
-
-app_threads_init :: proc() -> bool {
-	game_thread_idx := cast(int)ThreadID.GAME
-	game_thread := thread.create(game_thread_proc)
-	game_thread.user_index = game_thread_idx
-	game_thread.data = &game_data
-	app_threads.threads[game_thread_idx] = game_thread
-
-	render_thread_idx := cast(int)ThreadID.RENDER
-	render_thread := thread.create(render_thread_proc)
-	render_thread.user_index = render_thread_idx
-	render_thread.data = &render_data
-	app_threads.threads[render_thread_idx] = render_thread
-
-	audio_thread_idx := cast(int)ThreadID.AUDIO
-	audio_thread := thread.create(audio_thread_proc)
-	audio_thread.user_index = audio_thread_idx
-	audio_thread.data = &audio_data
-	app_threads.threads[audio_thread_idx] = audio_thread
-
-	return true
-}
-
-app_threads_start :: proc() {
-	log.debug("Starting threads...")
-
-	for i in 0 ..< ThreadCount {
-		assert(app_threads.threads[i] != nil, "Thread must be initialized before starting.")
-		thread.start(app_threads.threads[i])
-	}
-}
-
-app_threads_stop :: proc() -> bool {
-	log.debug("Stopping threads...")
-
-	sync.mutex_lock(&app_threads.shutdown_mutex)
-	app_threads.shutdown_requested = true
-	sync.mutex_unlock(&app_threads.shutdown_mutex)
-
-	for i in 0 ..< ThreadCount {
-		if app_threads.threads[i] == nil {
-			log.debugf("Thread {} is nil, skipping shutdown.", ThreadID(i))
-			continue
-		}
-
-		log.debugf("Stopping thread {}...", ThreadID(i))
-
-		thread.join(app_threads.threads[i])
-	}
-
-	for i in 0 ..< ThreadCount {
-		if app_threads.threads[i] == nil {continue}
-		thread.destroy(app_threads.threads[i])
-	}
-
-	return true
-}
-
-GameThreadData :: struct {}
-
-game_thread_proc :: proc(t: ^thread.Thread) {
-	context.logger = log.create_console_logger()
-
-	log.debug("Game thread starting...")
-	defer log.debug("Game thread exiting...")
-
-	for {
-		sync.mutex_lock(&app_threads.shutdown_mutex)
-		shutdown_requested := app_threads.shutdown_requested
-		sync.mutex_unlock(&app_threads.shutdown_mutex)
-
-		if shutdown_requested {break}
-
-		time.sleep(time.Millisecond * 10)
-	}
-}
-
-RenderThreadData :: struct {}
-
-render_thread_proc :: proc(t: ^thread.Thread) {
-	context.logger = log.create_console_logger()
-
-	log.debug("Render thread starting...")
-	defer log.debug("Render thread exiting...")
-
-	for {
-		sync.mutex_lock(&app_threads.shutdown_mutex)
-		shudown_requested := app_threads.shutdown_requested
-		sync.mutex_unlock(&app_threads.shutdown_mutex)
-
-		if shudown_requested {break}
-
-		time.sleep(time.Millisecond * 10)
-	}
-}
-
-AudioThreadData :: struct {}
-
-audio_thread_proc :: proc(t: ^thread.Thread) {
-	context.logger = log.create_console_logger()
-
-	log.debug("Audio thread starting...")
-	defer log.debug("Audio thread exiting...")
-
-	for {
-		sync.mutex_lock(&app_threads.shutdown_mutex)
-		shudown_requested := app_threads.shutdown_requested
-		sync.mutex_unlock(&app_threads.shutdown_mutex)
-
-		if shudown_requested {break}
-
-		time.sleep(time.Millisecond * 10)
-	}
-}
-
 main :: proc() {
-	context.logger = log.create_console_logger()
+	context.logger = log.create_console_logger(opt = app.log_opts)
 
-	app.cli_parse()
-
-	state: app.AppState
-
-	app.sdl_init()
-	defer app.sdl_deinit()
-
-	app_threads_init()
-	defer app_threads_stop()
-
-	app_threads_start()
+	app.app_init()
+	defer app.app_deinit()
 
 	game, ok := app.game_api_load()
 	if !ok {return}
@@ -167,10 +24,10 @@ main :: proc() {
 	game_init(game)
 	defer game_deinit(game)
 
-	if app.cli_options().check {
-		// TODO
-		// Wait for all threads to finish initialization
+	app.app_thread_data.initialized = true
+	app.app_init_wait()
 
+	if app.cli_options().check {
 		log.info("App initialized successfully, exiting.")
 		return
 	}

--- a/src/entry/develop/main.odin
+++ b/src/entry/develop/main.odin
@@ -27,6 +27,7 @@ main :: proc() {
 
 	for {
 		if quit := app.sdl_poll_events(); quit {break}
+		time.sleep(10 * time.Millisecond)
 	}
 }
 

--- a/src/entry/release/main.odin
+++ b/src/entry/release/main.odin
@@ -4,20 +4,17 @@ import "../../app"
 import "../../game"
 import "base:runtime"
 import "core:log"
+import "core:time"
 import sdl "vendor:sdl3"
 
 main :: proc() {
 	context.logger = log.create_console_logger()
 
-	app.cli_parse()
+	app.app_init()
+	defer app.app_deinit()
 
-	state: app.AppState
-
-	app.sdl_init()
-	defer app.sdl_deinit()
-
-	game_init()
-	defer game_deinit()
+	app.app_thread_data.initialized = true
+	app.app_init_wait()
 
 	if app.cli_options().check {
 		log.info("App initialized successfully, exiting.")
@@ -26,7 +23,7 @@ main :: proc() {
 
 	for {
 		if quit := app.sdl_poll_events(); quit {break}
-		game_update()
+		time.sleep(10 * time.Millisecond)
 	}
 }
 

--- a/src/entry/release/main.odin
+++ b/src/entry/release/main.odin
@@ -13,32 +13,18 @@ main :: proc() {
 	app.app_init()
 	defer app.app_deinit()
 
-	app.app_thread_data.initialized = true
-	app.app_init_wait()
-
 	if app.cli_options().check {
 		log.info("App initialized successfully, exiting.")
 		return
 	}
 
 	for {
+		app.thread_clock_frame_start(&app.state.threads.app_data.clock)
+
 		if quit := app.sdl_poll_events(); quit {break}
-		time.sleep(10 * time.Millisecond)
+
+		app.thread_clock_frame_end(&app.state.threads.app_data.clock)
+		app.thread_clock_sleep(&app.state.threads.app_data.clock)
 	}
-}
-
-game_init :: proc "c" () {
-	context = runtime.default_context()
-	game.game_init()
-}
-
-game_deinit :: proc "c" () {
-	context = runtime.default_context()
-	game.game_deinit()
-}
-
-game_update :: proc "c" () {
-	context = runtime.default_context()
-	game.game_update()
 }
 


### PR DESCRIPTION
- **application threading setup**
- **wait for app initialization. refactor threads to app**
- **move game library load to game thread**
- **add thread support to release**
- **Thread clock and thread timing**

What:

Running the application components on different threads.
Running is a strong word. Mostly empty threads are spinning until the
application exits. There's no real logic on the threads yet.

A basic shutdown check on each thread so it exits when it is told to.
It depends on the child thread happily responding to the shutdown signal.

The hot reloading code related to loading/unloading the game code is now located
on the game thread. I think, the game data reloading code should also be located
on the game thread. Maybe not though.

The release thread now runs the same logic as the dev thread in the application
package. I guess the difference between develop & release has moved to the game
package. For now, eventually there will be application release specific code.
Code such as display flash screens, user agreements, commercial ability
requirements, external api client setup(interact with Discord/Twitch/etc).
This means I should keep the separate develop/release files in app package even
though they look the same now.

The thread clocking is now integrated on every thread.
It is a simple sleep based on remaining desired frame time.
Not exact enough for super tight timing, but an effective frame limiter.

